### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/apriltag_detector/CMakeLists.txt
+++ b/apriltag_detector/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(sensor_msgs REQUIRED)
 #
 add_library(${PROJECT_NAME} INTERFACE
   include/apriltag_detector/detector.hpp)
-  ament_target_dependencies(${PROJECT_NAME} INTERFACE sensor_msgs apriltag_msgs)
+  target_link_libraries(${PROJECT_NAME} INTERFACE ${sensor_msgs_TARGETS} ${apriltag_msgs_TARGETS})
 
 target_include_directories(
   ${PROJECT_NAME}
@@ -76,5 +76,3 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
-
-

--- a/apriltag_detector_mit/CMakeLists.txt
+++ b/apriltag_detector_mit/CMakeLists.txt
@@ -21,23 +21,27 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(apriltag_mit)
+find_package(apriltag_detector REQUIRED)
+find_package(apriltag_mit REQUIRED)
+find_package(apriltag_msgs REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core imgproc)
 
 set(ament_dependencies
-  "apriltag_detector"
-  "apriltag_msgs"
-  "cv_bridge"
-  "image_transport"
-  "pluginlib"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs")
-
-foreach(pkg ${ament_dependencies})
-  find_package(${pkg} REQUIRED)
-endforeach()
+  apriltag_detector::apriltag_detector
+  ${apriltag_msgs_TARGETS}
+  cv_bridge::cv_bridge
+  image_transport::image_transport
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${sensor_msgs_TARGETS})
 
 if(${cv_bridge_VERSION} GREATER "3.3.0")
   add_definitions(-DUSE_CV_BRIDGE_HPP)
@@ -45,15 +49,13 @@ endif()
 
 pluginlib_export_plugin_description_file(apriltag_detector plugins.xml)
 
-
 #
 # --------- plugin library with node-free detector (exported)
 #
 add_library(${PROJECT_NAME} SHARED
   src/detector.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${ament_dependencies})
-target_link_libraries(${PROJECT_NAME} apriltag_mit::apriltag_mit)
+target_link_libraries(${PROJECT_NAME} ${ament_dependencies} apriltag_mit::apriltag_mit)
 
 target_include_directories(
   ${PROJECT_NAME}
@@ -70,7 +72,7 @@ ament_export_libraries(${PROJECT_NAME})
 add_library(${PROJECT_NAME}_component SHARED
   src/component.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_component ${ament_dependencies})
+target_link_libraries(${PROJECT_NAME}_component ${ament_dependencies})
 target_link_libraries(${PROJECT_NAME}_component ${PROJECT_NAME})
 
 target_include_directories(

--- a/apriltag_detector_umich/CMakeLists.txt
+++ b/apriltag_detector_umich/CMakeLists.txt
@@ -21,30 +21,35 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+find_package(apriltag REQUIRED)
+find_package(apriltag_detector REQUIRED)
+find_package(apriltag_msgs REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core imgproc)
 
 set(ament_dependencies
-  "apriltag"
-  "apriltag_detector"
-  "apriltag_msgs"
-  "cv_bridge"
-  "image_transport"
-  "pluginlib"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs")
-
-foreach(pkg ${ament_dependencies})
-  find_package(${pkg} REQUIRED)
-endforeach()
+  apriltag
+  apriltag_detector::apriltag_detector
+  ${apriltag_msgs_TARGETS}
+  cv_bridge::cv_bridge
+  image_transport::image_transport
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${sensor_msgs_TARGETS}
+)
 
 if(${cv_bridge_VERSION} GREATER "3.3.0")
   add_definitions(-DUSE_CV_BRIDGE_HPP)
 endif()
 
 pluginlib_export_plugin_description_file(apriltag_detector plugins.xml)
-
 
 #
 # --------- plugin library with node-free detector (exported)
@@ -53,8 +58,7 @@ add_library(${PROJECT_NAME} SHARED
   src/detector_impl.cpp
   src/detector.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${ament_dependencies})
-target_link_libraries(${PROJECT_NAME} apriltag)
+target_link_libraries(${PROJECT_NAME} ${ament_dependencies})
 
 target_include_directories(
   ${PROJECT_NAME}
@@ -71,8 +75,7 @@ ament_export_libraries(${PROJECT_NAME})
 add_library(${PROJECT_NAME}_component SHARED
   src/component.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}_component ${ament_dependencies})
-target_link_libraries(${PROJECT_NAME}_component ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_component ${ament_dependencies} ${PROJECT_NAME})
 
 target_include_directories(
   ${PROJECT_NAME}_component

--- a/apriltag_draw/CMakeLists.txt
+++ b/apriltag_draw/CMakeLists.txt
@@ -20,19 +20,22 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(apriltag_msgs REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core imgproc)
 
 set(ament_dependencies
-  "rclcpp"
-  "rclcpp_components"
-  "image_transport"
-  "cv_bridge"
-  "sensor_msgs"
-  "apriltag_msgs")
-
-foreach(pkg ${ament_dependencies})
-  find_package(${pkg} REQUIRED)
-endforeach()
+  rclcpp::rclcpp
+  rclcpp_components::component
+  image_transport::image_transport
+  cv_bridge::cv_bridge
+  ${sensor_msgs_TARGETS}
+  ${apriltag_msgs_TARGETS}
+)
 
 if(${cv_bridge_VERSION} VERSION_GREATER "3.3.0")
   add_definitions(-DUSE_CV_BRIDGE_HPP)
@@ -44,9 +47,7 @@ endif()
 add_library(${PROJECT_NAME} SHARED
   src/apriltag_draw.cpp)
 
-ament_target_dependencies(${PROJECT_NAME} ${ament_dependencies})
-target_link_libraries(${PROJECT_NAME} opencv_core opencv_imgproc)
-
+target_link_libraries(${PROJECT_NAME} ${ament_dependencies} opencv_core opencv_imgproc)
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 rclcpp_components_register_nodes(${PROJECT_NAME} "${PROJECT_NAME}::ApriltagDraw")

--- a/apriltag_draw/package.xml
+++ b/apriltag_draw/package.xml
@@ -20,7 +20,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
 
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.
