### PR TITLE
Fix compilation and loading of shared libraries on Windows

### DIFF
--- a/apriltag_detector/CMakeLists.txt
+++ b/apriltag_detector/CMakeLists.txt
@@ -16,7 +16,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(apriltag_detector)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -81,8 +84,7 @@ ament_export_dependencies(sensor_msgs apriltag_msgs image_transport cv_bridge
 install(TARGETS
   ${PROJECT_NAME}
   ${PROJECT_NAME}_component
-  EXPORT ${PROJECT_NAME}_export
-  DESTINATION lib)
+  EXPORT ${PROJECT_NAME}_export)
 
 # the node must go into the project specific lib directory or else the launch
 # file will not find it

--- a/apriltag_detector_mit/CMakeLists.txt
+++ b/apriltag_detector_mit/CMakeLists.txt
@@ -16,7 +16,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(apriltag_detector_mit)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -62,8 +65,7 @@ ament_export_libraries(${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}_export
-  DESTINATION lib)
+  EXPORT ${PROJECT_NAME}_export)
 
 if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)

--- a/apriltag_detector_umich/CMakeLists.txt
+++ b/apriltag_detector_umich/CMakeLists.txt
@@ -16,7 +16,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(apriltag_detector_umich)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -64,8 +67,7 @@ ament_export_libraries(${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}_export
-  DESTINATION lib)
+  EXPORT ${PROJECT_NAME}_export)
 
 if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)

--- a/apriltag_draw/CMakeLists.txt
+++ b/apriltag_draw/CMakeLists.txt
@@ -16,7 +16,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(apriltag_draw)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -83,7 +86,6 @@ install(TARGETS
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}_export
-  DESTINATION lib
 )
 
 install(

--- a/apriltag_tools/CMakeLists.txt
+++ b/apriltag_tools/CMakeLists.txt
@@ -16,7 +16,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(apriltag_tools)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Fix https://github.com/ros-misc-utilities/apriltag_detector/issues/6 . 

There are three kind of fixes, listed in the following. If useful, I can split them in separate commits and/or PRs:
* Only add GCC/Clang specific options on GCC/Clang
* For the packages that build shared libraries, define `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` to ensure that the libraries export all their symbols, as done in Linux and macOS.
* Fix installation of shared libraries: in Windows the shared libraries are composed by two parts, the `.lib` import library used in linking (that are installed in `$CMAKE_INSTALL_PREFIX/lib`), and the `.dll` library used in loading (`$CMAKE_INSTALL_PREFIX/bin`). The current cmake code installs both of them in `$CMAKE_INSTALL_PREFIX/lib`, creating runtime problems (see https://github.com/RoboStack/ros-jazzy/issues/70). Since CMake 3.16 (the minimum version supported here) the easiest solution to install libraries in the correct locations is just to remove the `DESTINATION` argument from `install(TARGETS`, as the default locations are the correct ones: https://cmake.org/cmake/help/v3.16/command/install.html#installing-files .